### PR TITLE
Fluid 4559 - Re-wiring the timeupdate event to control the timing for the updates on time progress and captions

### DIFF
--- a/js/VideoPlayer_captionLoader.js
+++ b/js/VideoPlayer_captionLoader.js
@@ -39,7 +39,7 @@ https://source.fluidproject.org/svn/LICENSE.txt
         invokers: {
             convertToMilli: {
                 funcName: "fluid.videoPlayer.captionLoader.convertToMilli",
-                args: ["@0"]
+                args: ["{arguments}.0"]
             }  
         },
         intervalList: null
@@ -47,21 +47,36 @@ https://source.fluidproject.org/svn/LICENSE.txt
     
     /**
      * Convert the time in the format of hh:mm:ss.mmm to milliseconds.
-     * The time is normally extracted from the subtitle files in WebVTT or json format.
+     * The time is normally extracted from the subtitle files in WebVTT compatible format.
+     * WebVTT standard for timestamp: http://dev.w3.org/html5/webvtt/#webvtt-cue-timings
      * 
-     * @param time: in the format hh:mm:ss.mmm
+     * @param time: in the format hh:mm:ss.mmm ("hh:" is optional)
      * @return a number in millisecond
      * TODO: This should be removed once capscribe desktop gives us the time in millis in the captions
      */
     fluid.videoPlayer.captionLoader.convertToMilli = function (time) {
-        if (!time || !time.match(/^\d{2}:\d{2}:\d{2}\.\d{1,3}$/)) {
+        if (!time || !time.match(/^(\d{2}:)?\d{2}:\d{2}\.\d{1,3}$/)) {
             return null;
         }
         
         var splitTime = time.split(":");
-        var splitSec = splitTime[2].split(".");
-        var hours = parseFloat(splitTime[0]);
-        var mins = parseFloat(splitTime[1]) + (hours * 60);
+        
+        // Handle the optional "hh:" in the input
+        if (splitTime.length === 2) {
+            // "hh:" part is NOT given
+            var hourStr = "0";
+            var minStr = splitTime[0];
+            var secWithMilliSecStr = splitTime[1];
+        } else {
+            // "hh:" part is given
+            var hourStr = splitTime[0];
+            var minStr = splitTime[1];
+            var secWithMilliSecStr = splitTime[2];
+        }
+        
+        var splitSec = secWithMilliSecStr.split(".");
+        var hours = parseFloat(hourStr);
+        var mins = parseFloat(minStr) + (hours * 60);
         var secs = parseFloat(splitSec[0]) + (mins * 60);
         return Math.round(secs * 1000 + parseInt(splitSec[1], 10));
     };

--- a/js/VideoPlayer_intervalEventsConductor.js
+++ b/js/VideoPlayer_intervalEventsConductor.js
@@ -83,15 +83,10 @@ https://source.fluidproject.org/svn/LICENSE.txt
             return previousInterval;
         }
         
-        // Find out the interval that the current time fits in
-        for (var intervalId in intervalList) {
-            if (fluid.videoPlayer.intervalEventsConductor.inInterval(currentTimeInMillis, intervalList[intervalId])) {
-                return intervalId;
-            }
-        }
-        
-        // The current time does not fit in any interval
-        return null;
+        // Find out the interval that the current time fits in. If none was found, return null
+        return fluid.find(intervalList, function (interval, intervalId) {
+            return fluid.videoPlayer.intervalEventsConductor.inInterval(currentTimeInMillis, interval) ? intervalId : undefined;
+        }, null);
     };
 
     /**

--- a/tests/js/VideoPlayerCaptionLoaderTests.js
+++ b/tests/js/VideoPlayerCaptionLoaderTests.js
@@ -64,6 +64,13 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             testConvertToMilli("00:01:00.000", 60000);
             testConvertToMilli("01:00:00.000", 3600000);
             testConvertToMilli("01:01:01.001", 3661001);
+
+            // "hh" is optional and not provided
+            testConvertToMilli("00:00.1", 1);
+            testConvertToMilli("00:00.02", 2);
+            testConvertToMilli("00:00.003", 3);
+            testConvertToMilli("00:01.000", 1000);
+            testConvertToMilli("01:00.000", 60000);
         });
         
         videoPlayerCaptionLoaderTests.asyncTest("loadCaption", function () {

--- a/tests/js/VideoPlayerIntervalEventsConductorTests.js
+++ b/tests/js/VideoPlayerIntervalEventsConductorTests.js
@@ -44,11 +44,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         
         videoPlayerIntervalEventsConductorTests.test("findCurrentInterval", function () {
             testFindCurrentInterval(0.1, null, null);
-            testFindCurrentInterval(1.1, null, "0");
-            testFindCurrentInterval(1.5, "0", "0");
-            testFindCurrentInterval(2.1, "0", "1");
-            testFindCurrentInterval(3.5, "1", null);
-            testFindCurrentInterval(4, null, "2");
+            testFindCurrentInterval(1.1, null, 0);
+            testFindCurrentInterval(1.5, 0, 0);
+            testFindCurrentInterval(2.1, 0, 1);
+            testFindCurrentInterval(3.5, 1, null);
+            testFindCurrentInterval(4, null, 2);
         });
         
         videoPlayerIntervalEventsConductorTests.test("Test onTimeChange event", function () {


### PR DESCRIPTION
This branch is based off FLUID-4545 branch: That branch should be merged first. 

Re-wiring timeupdate event to a few different events that are fired at the proper timing to update the time progress or captions,
1. Reduces the overhead of computing and loading captions at an unnecessarily frequent interval 
2. Makes the timing control more public and easier to be manipulated by other sources, for instance, the non-html5 video player.
