### PR TITLE
FLUID-4801: Ensure the <object> element inside the <video> element is no...

### DIFF
--- a/js/VideoPlayer.js
+++ b/js/VideoPlayer.js
@@ -571,7 +571,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             }
 
             that.locate("controllers").hide();
-            
+
+            // Ensure <object> element is not in tab order, for IE9
+            $("object", that.locate("video")).attr("tabindex", "-1")
+
             that.events.onReady.fire(that);
         });
         


### PR DESCRIPTION
...t in the tab order (for IE9).

The <object> element inside the <video> element is, by default, in the tab order in IE9 (not in FF). It is interfering with the normal tab access to the controllers. Manually removing it from the tab order eliminates the problem. 
