### PR TITLE
FLUID-4749: Add title to volume controls container.

### DIFF
--- a/html/videoPlayer_template.html
+++ b/html/videoPlayer_template.html
@@ -14,7 +14,7 @@
                 <div class="fl-videoPlayer-controller-buttons-main">
                     <button type="button" class="flc-videoPlayer-play fl-videoPlayer-button"></button>
         
-                    <div class="flc-videoPlayer-volumeContainer fl-videoPlayer-volumeContainer">
+                    <div class="flc-videoPlayer-volumeContainer fl-videoPlayer-volumeContainer" title="Volume controls. Use up and down arrows to adjust volume, space or enter to mute">
                         <button type="button" class="flc-videoPlayer-mute fl-videoPlayer-button"></button>
                         <div class="flc-videoPlayer-volumeControl"></div>
                     </div>


### PR DESCRIPTION
Because focus never actually lands on the volume mute button or slider (only the container), the default info for those contols is never spoken. A title on the container is spoken; using that to provide info and instructions.
