### PR TITLE
FLUID-4818: Replacing 'buffered' in the model which was an object that c...

### DIFF
--- a/js/VideoPlayer.js
+++ b/js/VideoPlayer.js
@@ -292,7 +292,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             },
             currentTime: 0,
             totalTime: 0,
-            buffered: undefined,        // a TimeRanges object (http://www.whatwg.org/specs/web-apps/current-work/#time-ranges) set through browser events
+            bufferEnd: 0,
             displayCaptions: false,
             displayTranscripts: false,
             fullscreen: false,

--- a/js/VideoPlayer_controllers.js
+++ b/js/VideoPlayer_controllers.js
@@ -248,7 +248,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
         // Bind to the video's timeupdate event so we can programmatically update the slider.
         that.applier.modelChanged.addListener("currentTime", that.updateCurrent);
-        that.applier.modelChanged.addListener("buffered", that.updateBuffered);
+        that.applier.modelChanged.addListener("bufferEnd", that.updateBuffered);
 
         that.applier.modelChanged.addListener("canPlay", function () {
             var scrubber = that.locate("scrubber");
@@ -325,10 +325,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     var bufferCompleted = false;
     
     fluid.videoPlayer.controllers.scrubber.updateBuffered = function (that) {
-        // "model.buffered" is a TimeRanges object set by the browser timeupdate event 
-        //    (http://www.whatwg.org/specs/web-apps/current-work/#time-ranges)
-        var bufferedExists = that.model.buffered && (that.model.buffered.length > 0);
-        var lastBufferedTime = bufferedExists ? that.model.buffered.end(that.model.buffered.length - 1) : 0;
+        var lastBufferedTime = that.model.bufferEnd;
         var totalTime = that.model.totalTime;
 
         // Turn on buffer progress update if the re-buffering is triggered, for instance, 

--- a/js/VideoPlayer_media.js
+++ b/js/VideoPlayer_media.js
@@ -198,13 +198,16 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
 
     fluid.videoPlayer.media.preInit = function (that) {
         that.updateCurrentTime = function (currentTime, buffered) {
+            // buffered is a TimeRanges object (http://www.whatwg.org/specs/web-apps/current-work/#time-ranges)
+            var bufferEnd = buffered ? buffered.end(buffered.length - 1) : 0;
+
             that.applier.fireChangeRequest({
                 path: "currentTime", 
                 value: currentTime
             });
             that.applier.fireChangeRequest({
-                path: "buffered", 
-                value: buffered
+                path: "bufferEnd",
+                value: bufferEnd
             });
         };
         

--- a/tests/js/VideoPlayerControlsTests.js
+++ b/tests/js/VideoPlayerControlsTests.js
@@ -92,17 +92,9 @@ fluid.registerNamespace("fluid.tests");
                 }
             });
         });
-
-        var testBufferEndTime;
         
         var baseScrubberOpts = {
             model: {
-                buffered: {
-                    length: 1,
-                    end: function (index) {
-                        return testBufferEndTime;
-                    }
-                },
                 totalTime: 200
             }
         };
@@ -118,13 +110,13 @@ fluid.registerNamespace("fluid.tests");
             var scrubber = fluid.tests.initScrubber();
             
             fluid.videoPlayer.controllers.scrubber.updateBuffered(scrubber);
-            jqUnit.assertEquals("The buffer progress bar should not get updated with undefined buffered value", "0", scrubber.locate("bufferedProgressBar").attr("aria-valuenow"));
+            jqUnit.assertEquals("The buffer progress bar should not get updated when bufferEnd is not set", "0", scrubber.locate("bufferedProgressBar").attr("aria-valuenow"));
 
-            testBufferEndTime = 100;
+            scrubber.applier.requestChange("bufferEnd", 100);
             fluid.videoPlayer.controllers.scrubber.updateBuffered(scrubber);
             jqUnit.assertEquals("The buffer progress bar should have valuenow of '50'", "50", scrubber.locate("bufferedProgressBar").attr("aria-valuenow"));
 
-            testBufferEndTime = 200;
+            scrubber.applier.requestChange("bufferEnd", 200);
             fluid.videoPlayer.controllers.scrubber.updateBuffered(scrubber);
             jqUnit.assertEquals("The buffer progress bar should have valuenow of '100'", "100", scrubber.locate("bufferedProgressBar").attr("aria-valuenow"));
 


### PR DESCRIPTION
...an not be safely passed around, with 'bufferEnd' which is a simple property.
