### PR TITLE
FLUID-4835: Update processing of Amara timecodes to reflect switch to mi...

### DIFF
--- a/js/VideoPlayer.js
+++ b/js/VideoPlayer.js
@@ -652,11 +652,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     });
 
     /*******************************************************************
-     * Converts seconds into a WebVTT Timestamp:  HH:MM:SS.mmm
-     * @seconds:  time in seconds expressed as a floating point number
+     * Converts milliseconds into a WebVTT Timestamp:  HH:MM:SS.mmm
+     * @seconds:  time in milliseconds expressed as a floating point number
      *******************************************************************/
-    fluid.videoPlayer.secondsToHmsm = function (seconds) {
-        seconds = parseFloat(seconds);
+    fluid.videoPlayer.millisToHmsm = function (millis) {
+        seconds = parseFloat(millis)/1000;
         seconds = seconds < 0 || isNaN(seconds) ? 0 : seconds;
 
         var hours = parseInt(seconds / 3600);
@@ -681,8 +681,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var vtt = "WEBVTT";
 
         for (var i = 0; i < json.length; i++) {
-            var startTime = fluid.videoPlayer.secondsToHmsm(json[i].start_time);
-            var endTime = fluid.videoPlayer.secondsToHmsm(json[i].end_time);
+            var startTime = fluid.videoPlayer.millisToHmsm(json[i].start_time);
+            var endTime = fluid.videoPlayer.millisToHmsm(json[i].end_time);
             vtt = vtt.concat("\n\n", startTime, " --> ", endTime, "\n", json[i].text);
         }
 

--- a/js/VideoPlayer_transcript.js
+++ b/js/VideoPlayer_transcript.js
@@ -270,7 +270,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             // Handle Universal Subtitles JSON files for transcripts
             if (transcriptSource.type === "text/amarajson") {
                 fluid.videoPlayer.fetchAmaraJson(transcriptSource.src, function (data) {
-                    fluid.videoPlayer.transcript.parseTranscriptFile(that, data, currentIndex, that.convertSecsToMilli, "text", "start_time", "end_time");
+                    fluid.videoPlayer.transcript.parseTranscriptFile(that, data, currentIndex, fluid.identity, "text", "start_time", "end_time");
                 });
             } else {
                 var opts = {

--- a/tests/js/VideoPlayerTests.js
+++ b/tests/js/VideoPlayerTests.js
@@ -60,29 +60,29 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var testVTTCaption = function (vttArray, index, captionObj) {
             jqUnit.assertEquals("First line is empty", "", vttArray[index]);
 
-            var times = fluid.videoPlayer.secondsToHmsm(captionObj.start_time) + " --> " + fluid.videoPlayer.secondsToHmsm(captionObj.end_time);
+            var times = fluid.videoPlayer.millisToHmsm(captionObj.start_time) + " --> " + fluid.videoPlayer.millisToHmsm(captionObj.end_time);
 
             jqUnit.assertEquals("Times are correctly specified", times, vttArray[index + 1]);
             jqUnit.assertEquals("Caption is in the correct position", captionObj.text, vttArray[index + 2]);
         };
 
-        videoPlayerTests.test("secondsToHmsm", function () {
+        videoPlayerTests.test("millisToHmsm", function () {
             jqUnit.expect(15);
-            jqUnit.assertEquals("0 seconds", "00:00:00.000", fluid.videoPlayer.secondsToHmsm(0));
-            jqUnit.assertEquals("1 milli seconds", "00:00:00.100", fluid.videoPlayer.secondsToHmsm(0.1));
-            jqUnit.assertEquals("1111 milli seconds", "00:00:00.111", fluid.videoPlayer.secondsToHmsm(0.1111));
-            jqUnit.assertEquals("10 seconds", "00:00:10.000", fluid.videoPlayer.secondsToHmsm(10));
-            jqUnit.assertEquals("1 minute", "00:01:00.000", fluid.videoPlayer.secondsToHmsm(60));
-            jqUnit.assertEquals("59 minutes", "00:59:00.000", fluid.videoPlayer.secondsToHmsm("3540"));
-            jqUnit.assertEquals("59 minutes and 59 seconds", "00:59:59.000", fluid.videoPlayer.secondsToHmsm(3599));
-            jqUnit.assertEquals("1 hour", "01:00:00.000", fluid.videoPlayer.secondsToHmsm(3600));
-            jqUnit.assertEquals("25 hours", "25:00:00.000", fluid.videoPlayer.secondsToHmsm(90000));
-            jqUnit.assertEquals("1 hour, 1 min, 1 sec", "01:01:01.000", fluid.videoPlayer.secondsToHmsm(3661));
-            jqUnit.assertEquals("7 minutes and 5 seconds", "00:07:05.000", fluid.videoPlayer.secondsToHmsm(425));
-            jqUnit.assertEquals("10 hours and 12 minutes", "10:12:00.000", fluid.videoPlayer.secondsToHmsm(36720));
-            jqUnit.assertEquals("100 hours", "100:00:00.000", fluid.videoPlayer.secondsToHmsm(360000));
-            jqUnit.assertEquals("Negative number - return 0", "00:00:00.000", fluid.videoPlayer.secondsToHmsm(-1));
-            jqUnit.assertEquals("letter - return 0", "00:00:00.000", fluid.videoPlayer.secondsToHmsm("x"));
+            jqUnit.assertEquals("0 seconds", "00:00:00.000", fluid.videoPlayer.millisToHmsm(0));
+            jqUnit.assertEquals("1 milli seconds", "00:00:00.100", fluid.videoPlayer.millisToHmsm(100));
+            jqUnit.assertEquals("1111 milli seconds", "00:00:00.111", fluid.videoPlayer.millisToHmsm(111.1));
+            jqUnit.assertEquals("10 seconds", "00:00:10.000", fluid.videoPlayer.millisToHmsm(10000));
+            jqUnit.assertEquals("1 minute", "00:01:00.000", fluid.videoPlayer.millisToHmsm(60000));
+            jqUnit.assertEquals("59 minutes", "00:59:00.000", fluid.videoPlayer.millisToHmsm("3540000"));
+            jqUnit.assertEquals("59 minutes and 59 seconds", "00:59:59.000", fluid.videoPlayer.millisToHmsm(3599000));
+            jqUnit.assertEquals("1 hour", "01:00:00.000", fluid.videoPlayer.millisToHmsm(3600000));
+            jqUnit.assertEquals("25 hours", "25:00:00.000", fluid.videoPlayer.millisToHmsm(90000000));
+            jqUnit.assertEquals("1 hour, 1 min, 1 sec", "01:01:01.000", fluid.videoPlayer.millisToHmsm(3661000));
+            jqUnit.assertEquals("7 minutes and 5 seconds", "00:07:05.000", fluid.videoPlayer.millisToHmsm(425000));
+            jqUnit.assertEquals("10 hours and 12 minutes", "10:12:00.000", fluid.videoPlayer.millisToHmsm(36720000));
+            jqUnit.assertEquals("100 hours", "100:00:00.000", fluid.videoPlayer.millisToHmsm(360000000));
+            jqUnit.assertEquals("Negative number - return 0", "00:00:00.000", fluid.videoPlayer.millisToHmsm(-1));
+            jqUnit.assertEquals("letter - return 0", "00:00:00.000", fluid.videoPlayer.millisToHmsm("x"));
         });
 
         videoPlayerTests.test("amaraJsonToVTT", function () {


### PR DESCRIPTION
...lliseconds.

@michelled: Amara changed their timecodes from second to milliseconds. This is why both the English captions and transcripts stopped working recently. This pull request addresses the change.
