### PR TITLE
VP-283: updating the licence info for captionator

### DIFF
--- a/lib/captionator/README.txt
+++ b/lib/captionator/README.txt
@@ -1,6 +1,11 @@
-Attribution:
- * Captionator.js is a JavaScript polyfill designed to provide support for the <track> element and TextTrack javascript API. It currently supports subtitles in SUB, SRT, Youtube's SBV, WebVTT, and WebVTT with Google's proposed timestamp syntax. It will soon support LRC, DFXP/TTML and the WebVTT v2 proposed features. More information could be found http://captionatorjs.com/
- * Captionator code is a completely free opensource software. More details on the license could be obtained on https://github.com/cgiffard/Captionator/tree/captionplanet
+Licence
+Copyright (c) 2012, Christopher Giffard All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Source:
  * Original code is available on GIT https://github.com/cgiffard/Captionator
@@ -9,3 +14,5 @@ Source:
 
 Instructions:
  * All necessary documentation about the Captionator could be found on the official Captionator website http://captionatorjs.com/
+ 
+ 


### PR DESCRIPTION
Updated the readme for our instance of the captionator to include the licence info.

http://issues.fluidproject.org/browse/VP-283
